### PR TITLE
feat: use config sent by pino to support custom message key and log levels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16, 18, 20]
+        pino-version: [^8.21.0, ^9.0.0]
         os: [ubuntu-latest]
     steps:
       - name: Checkout
@@ -28,6 +29,9 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+
+      - name: Install pino
+        run: npm install --no-save pino@${{ matrix.pino-version }}
 
       - name: Run Tests
         run: npm run test

--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,11 @@
+check-coverage: true
+coverage-report: 
+  - lcov
+  - text
+browser: false
+branches: 100
+lines: 100
+functions: 100
+statements: 100
+files: 
+  - "test/**/*.test.js"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ When using the transport, the following options can be used to configure the tra
 
 * `loggerName`: name to be used by the OpenTelemetry logger
 * `serviceVersion`: version to be used by the OpenTelemetry logger
-* `messageKey`: The key of the log message to be used as the OpenTelemetry log entry Body. Optional, value `msg` used by default (like in Pino itself). Optional
 * `severityNumberMap`: Object mapping Pino log level numbers to OpenTelemetry log severity numbers. This is an override for adding custom log levels and changing default log levels. Undefined default Pino log levels will still be mapped to their default OpenTelemetry log severity. Optional
 * `resourceAttributes`: Object containing [resource attributes](https://opentelemetry.io/docs/instrumentation/js/resources/). Optional
 * `logRecordProcessorOptions`: a single object or an array of objects specifying the LogProcessor and LogExporter types and constructor params. Optional

--- a/lib/opentelemetry-mapper.js
+++ b/lib/opentelemetry-mapper.js
@@ -14,35 +14,6 @@ const DEFAULT_SEVERITY_NUMBER_MAP = {
   60: 21 // FATAL
 }
 
-// https://github.com/open-telemetry/opentelemetry-specification/blob/fc8289b8879f3a37e1eba5b4e445c94e74b20359/specification/logs/data-model.md#displaying-severity
-const SEVERITY_NAME_MAP = {
-  0: 'UNSPECIFIED',
-  1: 'TRACE',
-  2: 'TRACE2',
-  3: 'TRACE3',
-  4: 'TRACE4',
-  5: 'DEBUG',
-  6: 'DEBUG2',
-  7: 'DEBUG3',
-  8: 'DEBUG4',
-  9: 'INFO',
-  10: 'INFO2',
-  11: 'INFO3',
-  12: 'INFO4',
-  13: 'WARN',
-  14: 'WARN2',
-  15: 'WARN3',
-  16: 'WARN4',
-  17: 'ERROR',
-  18: 'ERROR2',
-  19: 'ERROR3',
-  20: 'ERROR4',
-  21: 'FATAL',
-  22: 'FATAL2',
-  23: 'FATAL3',
-  24: 'FATAL4'
-}
-
 /**
  * @typedef {Object} CommonBindings
  * @property {string=} msg
@@ -60,13 +31,14 @@ const SEVERITY_NAME_MAP = {
  *
  * @typedef {Object} MapperOptions
  * @property {string} messageKey
+ * @property {import('pino').LevelMapping} levels
  * @property {Object.<number, number>} [severityNumberMap]
  *
  * @param {Bindings} sourceObject
  * @param {MapperOptions} mapperOptions
  * @returns {import('@opentelemetry/api-logs').LogRecord}
  */
-function toOpenTelemetry (sourceObject, { messageKey, severityNumberMap = {} }) {
+function toOpenTelemetry (sourceObject, { messageKey, levels, severityNumberMap = {} }) {
   const {
     time,
     level,
@@ -78,7 +50,7 @@ function toOpenTelemetry (sourceObject, { messageKey, severityNumberMap = {} }) 
 
   const severityNumber =
     severityNumberMap[sourceObject.level] ?? DEFAULT_SEVERITY_NUMBER_MAP[sourceObject.level] ?? 0
-  const severityText = SEVERITY_NAME_MAP[severityNumber] ?? 'UNSPECIFIED'
+  const severityText = levels.labels[sourceObject.level]
 
   /* eslint-disable camelcase */
   return {

--- a/lib/pino-opentelemetry-transport.js
+++ b/lib/pino-opentelemetry-transport.js
@@ -3,29 +3,27 @@
 const build = require('pino-abstract-transport')
 const { getOtlpLogger } = require('otlp-logger')
 const { toOpenTelemetry } = require('./opentelemetry-mapper')
-const DEFAULT_MESSAGE_KEY = 'msg'
 
 /**
  * Pino OpenTelemetry transport
  *
  * @typedef {Object} PinoOptions
- * @property {string} [messageKey="msg"]
  * @property {Object.<number, number>} [severityNumberMap]
  *
  * @typedef {PinoOptions & import('otlp-logger').Options} Options
  *
  * @param { Options } opts
  */
-module.exports = async function ({ messageKey = DEFAULT_MESSAGE_KEY, severityNumberMap, ...loggerOpts }) {
+module.exports = async function ({ severityNumberMap, ...loggerOpts }) {
   const logger = getOtlpLogger(loggerOpts)
-
-  const mapperOptions = {
-    messageKey,
-    severityNumberMap
-  }
 
   return build(
     async function (/** @type { AsyncIterable<Bindings> } */ source) {
+      const mapperOptions = {
+        messageKey: source.messageKey,
+        levels: source.levels,
+        severityNumberMap
+      }
       for await (const obj of source) {
         logger.emit(toOpenTelemetry(obj, mapperOptions))
       }
@@ -33,7 +31,8 @@ module.exports = async function ({ messageKey = DEFAULT_MESSAGE_KEY, severityNum
     {
       async close () {
         return logger.shutdown()
-      }
+      },
+      expectPinoConfig: true
     }
   )
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenTelemetry transport for Pino",
   "main": "lib/pino-opentelemetry-transport.js",
   "scripts": {
-    "validate-and-test": "standard | snazzy && tap test/**/*.test.js --branches=45 --lines=45 --functions=45 --statements=45 --coverage-report=lcovonly && tsd",
+    "validate-and-test": "standard | snazzy && tap && tsd",
     "test": "npm run validate-and-test",
     "docker-run": "docker compose up",
     "generate-types": "tsc",
@@ -16,10 +16,13 @@
   "repository": "github:pinojs/pino-opentelemetry-transport",
   "license": "MIT",
   "dependencies": {
-    "otlp-logger": "^1.1.0",
-    "pino-abstract-transport": "^1.1.0"
+    "otlp-logger": "^1.1.4",
+    "pino-abstract-transport": "^1.2.0"
   },
   "types": "./types/pino-opentelemetry-transport.d.ts",
+  "peerDependencies": {
+    "pino": "^8.21.0 || ^9.0.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "^19.0.3",
     "@commitlint/config-conventional": "^19.0.3",
@@ -27,7 +30,7 @@
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/api-logs": "^0.51.0",
     "@opentelemetry/instrumentation-http": "^0.51.0",
-    "@opentelemetry/instrumentation-pino": "^0.37.0",
+    "@opentelemetry/instrumentation-pino": "^0.38.0",
     "@opentelemetry/sdk-node": "^0.51.0",
     "@types/node": "^20.8.2",
     "pino": "^9.0.0",

--- a/test/lib/pino-opentelemetry-transport.test.js
+++ b/test/lib/pino-opentelemetry-transport.test.js
@@ -5,6 +5,7 @@ const { test, before } = require('tap')
 const requireInject = require('require-inject')
 const { Wait, GenericContainer } = require('testcontainers')
 const { extract } = require('tar-stream')
+const { SeverityNumber } = require('@opentelemetry/api-logs')
 const { text } = require('node:stream/consumers')
 const { setInterval } = require('node:timers/promises')
 
@@ -70,7 +71,7 @@ test('translate Pino log format to Open Telemetry data format for each log level
         }
       },
       severityNumberMap: {
-        35: 10
+        35: SeverityNumber.INFO2
       }
     }
   })
@@ -126,8 +127,8 @@ test('translate Pino log format to Open Telemetry data format for each log level
 
   const expectedLines = [
     {
-      severityNumber: 1,
-      severityText: 'TRACE',
+      severityNumber: SeverityNumber.TRACE,
+      severityText: 'trace',
       body: { stringValue: 'test trace' },
       traceId: testTraceId,
       spanId: testSpanId,
@@ -137,43 +138,43 @@ test('translate Pino log format to Open Telemetry data format for each log level
       ]
     },
     {
-      severityNumber: 5,
-      severityText: 'DEBUG',
+      severityNumber: SeverityNumber.DEBUG,
+      severityText: 'debug',
       body: { stringValue: 'test debug' },
       traceId: '',
       spanId: ''
     },
     {
-      severityNumber: 9,
-      severityText: 'INFO',
+      severityNumber: SeverityNumber.INFO,
+      severityText: 'info',
       body: { stringValue: 'test info' },
       traceId: '',
       spanId: ''
     },
     {
-      severityNumber: 10,
-      severityText: 'INFO2',
+      severityNumber: SeverityNumber.INFO2,
+      severityText: 'custom',
       body: { stringValue: 'test custom' },
       traceId: '',
       spanId: ''
     },
     {
-      severityNumber: 13,
-      severityText: 'WARN',
+      severityNumber: SeverityNumber.WARN,
+      severityText: 'warn',
       body: { stringValue: 'test warn' },
       traceId: '',
       spanId: ''
     },
     {
-      severityNumber: 17,
-      severityText: 'ERROR',
+      severityNumber: SeverityNumber.ERROR,
+      severityText: 'error',
       body: { stringValue: 'test error' },
       traceId: '',
       spanId: ''
     },
     {
-      severityNumber: 21,
-      severityText: 'FATAL',
+      severityNumber: SeverityNumber.FATAL,
+      severityText: 'fatal',
       body: { stringValue: 'test fatal' },
       traceId: '',
       spanId: ''

--- a/test/types/pino-opentelemetry-transport.test-d.ts
+++ b/test/types/pino-opentelemetry-transport.test-d.ts
@@ -6,14 +6,12 @@ import transport from '../../lib/pino-opentelemetry-transport'
 
 expectType<Promise<Transform & OnUnknown>>(
   transport({
-    messageKey: 'message',
     loggerName: 'test',
     serviceVersion: '1.0.0'
   })
 )
 expectType<Promise<Transform & OnUnknown>>(
   transport({
-    messageKey: 'message',
     loggerName: 'test',
     serviceVersion: '1.0.0',
     resourceAttributes: { 'service.name': 'test' }
@@ -23,5 +21,14 @@ expectType<Promise<Transform & OnUnknown>>(
   transport({
     loggerName: 'test',
     serviceVersion: '1.0.0'
+  })
+)
+expectType<Promise<Transform & OnUnknown>>(
+  transport({
+    loggerName: 'test',
+    serviceVersion: '1.0.0',
+    severityNumberMap: {
+      35: 10
+    }
   })
 )


### PR DESCRIPTION
This implements the new pino feature from pinojs/pino#1925 released in pino-abstract-transport@1.2.0 and pino@8.21.0

Supersedes #155
Fixes #153

BREAKING CHANGE:
- Requires peerDependency pino ^8.21.0 or ^9.0.0
- Removes messageKey option
- Changes severity text to log level name instead of OTel short name