### PR TITLE
feat!: bump otlp-logger from 1.1.13 to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "github:pinojs/pino-opentelemetry-transport",
   "license": "MIT",
   "dependencies": {
-    "otlp-logger": "^1.1.4",
+    "otlp-logger": "^2.0.0",
     "pino-abstract-transport": "^3.0.0"
   },
   "types": "./types/pino-opentelemetry-transport.d.ts",


### PR DESCRIPTION
BREAKING CHANGE: OTEL_NODE_RESOURCE_DETECTORS env var now controls resource detection. Previously ignored, may change behavior for users who had it set for other instrumentation.

Fixes #242 