### PR TITLE
fix(ci): drop EOL Node 20 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20, 22, 24, 26]
+        node-version: [22, 24, 26]
         pino-version: [^10.0.0]
         os: [ubuntu-latest]
     steps:


### PR DESCRIPTION
## Problem

CI fails on **Node 20** with the testcontainers integration test crashing at import:

```
TypeError: webidl.util.markAsUncloneable is not a function
  at new CacheStorage (testcontainers/node_modules/undici/.../cachestorage.js:20)
```

`testcontainers@12` depends on `undici@8`, which declares `engines.node >=22.19.0` and does `const { markAsUncloneable } = require('node:worker_threads')`. That export doesn't exist on Node 20, so the call is `undefined` → crash on import.

The 22/24/26 matrix jobs only *appeared* to fail because `fail-fast` cancelled them once Node 20 failed — the genuine failure is Node 20 only.

This is pre-existing on `main` (the gitignored `package-lock.json` means every CI install freshly resolves testcontainers 12 / undici 8); `main`'s last CI test run was cancelled, so it was never surfaced. It was exposed by #265, which is the first run to complete since the dependency drift.

## Fix

Drop Node 20 from the CI matrix (`[20, 22, 24, 26]` → `[22, 24, 26]`).

- Node 20 reached **EOL in April 2026**.
- The dev test tooling (testcontainers 12 / undici 8) requires Node ≥22.

Library runtime support is unchanged — no `engines` change — since this is a test-tooling constraint, not a consumer-facing one.


