### PR TITLE
chore(deps): ignore typescript 7 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
+    ignore:
+      # typescript-eslint (via neostandard) caps TS at <6.1.0; TS 7 crashes eslint.
+      # Hold on 6.x until the toolchain supports TS 7.
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
typescript-eslint (via neostandard) caps TS peer at <6.1.0; TS 7 breaks ts-api-utils and crashes eslint. hold TS on 6.x until toolchain supports 7.